### PR TITLE
Ignore node_modules/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /static/
 /server/build/
 /web-snack-libraries.tar.gz
+node_modules/


### PR DESCRIPTION
## Overview

May be a good idea to include this for people that don't have it in their global gitignore ☺️