### PR TITLE
Fall back to empty object when loading EDITOR_CONFIG_KEY

### DIFF
--- a/src/client/components/Preferences/PreferencesProvider.js
+++ b/src/client/components/Preferences/PreferencesProvider.js
@@ -48,7 +48,7 @@ let overrides = {};
 try {
   // Restore editor preferences from saved data
   if ('localStorage' in window) {
-    overrides = JSON.parse(window.localStorage.getItem(EDITOR_CONFIG_KEY));
+    overrides = JSON.parse(window.localStorage.getItem(EDITOR_CONFIG_KEY) || '{}');
   }
 } catch (e) {
   // Ignore error


### PR DESCRIPTION
When EDITOR_CONFIG_KEY is not defined yet in local storage, we need to provide a meaningful default value to avoid a TypError at runtime.

This might not be a proper fix and is meant to point you guys in the right direction.